### PR TITLE
Fixed AstRewriter set comprehension logic

### DIFF
--- a/PyComponent/PyInspect/AstRewriter.py
+++ b/PyComponent/PyInspect/AstRewriter.py
@@ -1377,7 +1377,8 @@ class ASTVisitor(NodeTransformer):
 
     def visit_setcomp(self, node):
         assign = Assign(targets=[self._new_tmp_name(Store())],
-                        value=Set(elts=[]),
+                        value=Call(func=Name(id='set', ctx=Load()),
+                            args=[], keywords=[]),
                         lineno=self._new_lineno(),
                         col_offset=self._col_offset)
         fix_missing_locations(assign)


### PR DESCRIPTION
The original code creates an empty dictionary `{}` and invokes `add` to add the elements, but 'dict' objects have no attribute 'add'.
Fix: create an empty set `set()`.


**Before/After Testing**

Setup:
```
$ cd PolyCruise/PyComponent
$ echo -e "test = {i for i in [1,2,3,4,5,5,5,6]}\nprint(test)" > test_set_comprehension.py
```

Before:
```
$ python pyinspect.py -c test_set_comprehension.py
> assert(t.elts) # should be at least one element
> AssertionError
```

After:
```
$ python pyinspect.py -c test_set_comprehension.py
$ python Temp/test_set_comprehension.py
> {1, 2, 3, 4, 5, 6}
```