### PR TITLE
Create a variable to hold the bytes constants

### DIFF
--- a/PyComponent/PyInspect/AstRewriter.py
+++ b/PyComponent/PyInspect/AstRewriter.py
@@ -996,13 +996,14 @@ class ASTVisitor(NodeTransformer):
         return Name(id=assign.targets[0].id, ctx=Load())
 
     def visit_bytes(self, node):
-        bytes = Bytes(s=node.s,
-                      lineno=self._new_lineno(),
-                      col_offset=self._col_offset)
-        fix_missing_locations(bytes)
-        #self._add_to_codelist(bytes)
-        return bytes
-        #raise NotImplementedError('bytes')
+        assign = Assign(targets=[self._new_tmp_name(Store())],
+                value=Bytes(s=node.s),
+                lineno=self._new_lineno(),
+                col_offset=self._col_offset)
+        fix_missing_locations(assign)
+        self._add_to_codelist(assign)
+        self._add_to_lineno2ids(self._lineno, self._get_ids(assign))
+        return Name(id=assign.targets[0].id, ctx=Load())
 
     def visit_num(self, node):
         assign = Assign(targets=[self._new_tmp_name(Store())],


### PR DESCRIPTION
Before/After Testing

**Setup:**
prepare file test_bytes.py based on an instruction in `python3.7/re.py` as follows:
```
_special_chars_map = {i: '\\' + chr(i) for i in b'()[]{}?*+-|^$\\.&~# \t\n\r\v\f'}
print(_special_chars_map)
```

**Before:**
```
python pyinspect.py -c test_bytes.py
AttributeError: 'Bytes' object has no attribute 'id'
```

**After:**
```
$ python pyinspect.py -c test_bytes.py
$ cat Temp/test_bytes.py
import builtins
v1 = {}
v4 = b'()[]{}?*+-|^$\\.&~# \t\n\r\x0b\x0c'
for (v2, v3) in builtins.enumerate(v4):
    i = v3
    v6 = '\\'
    v7 = chr(i)
    v5 = (v6 + v7)
    v1[i] = v5
_special_chars_map = v1
print(_special_chars_map)
$ python Temp/test_bytes.py
{40: '\\(', 41: '\\)', 91: '\\[', 93: '\\]', 123: '\\{', 125: '\\}', 63: '\\?', 42: '\\*', 43: '\\+', 45: '\\-', 124: '\\|', 94: '\\^', 36: '\\$', 92: '\\\\', 46: '\\.', 38: '\\&', 126: '\\~', 35: '\\#', 32: '\\ ', 9: '\\\t', 10: '\\\n', 13: '\\\r', 11: '\\\x0b', 12: '\\\x0c'}
```
